### PR TITLE
Modernize build configuration and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,19 +14,14 @@ buildscript {
     mavenCentral()
   }
 
-  dependencies {
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.42.0'
-    classpath 'com.bmuschko:gradle-tomcat-plugin:2.7.0'
-  }
 }
 
 plugins {
-     id "java"
-     id "war"
-     id "idea"
-     id "com.bmuschko.tomcat" version "2.7.0"
-     id "com.github.ben-manes.versions" version "0.42.0"
+    id "com.github.ben-manes.versions" version "0.52.0"
 }
+
+apply plugin: 'war'
+apply from: 'https://raw.github.com/gretty-gradle-plugin/gretty/master/pluginScripts/gretty.plugin'
 
 sourceCompatibility = 17
 version = '0.3.1'
@@ -38,23 +33,13 @@ repositories {
 }
 
 dependencies {
-   def tomcatVersion = '10.1.0-M14'
-    tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
-            "org.apache.tomcat.embed:tomcat-embed-logging-juli:${tomcatVersion}"
-    tomcat("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {
-        exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'}
    providedCompile("javax.servlet:javax.servlet-api:4.0.1")
-   implementation("org.springframework:spring-webmvc:6.0.0-M3")
+   implementation("org.springframework:spring-webmvc:6.0.23")
    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2")
    implementation("org.thymeleaf:thymeleaf-spring4:3.0.15.RELEASE")
-   implementation("org.ldaptive:ldaptive:2.1.0")
+   implementation("org.ldaptive:ldaptive:1.3.3")
     implementation("com.typesafe:config:1.4.2")
    testImplementation("junit:junit:4.13.2")
-}
-
-tomcat {
-    httpProtocol = 'org.apache.coyote.http11.Http11Nio2Protocol'
-    ajpProtocol  = 'org.apache.coyote.ajp.AjpNio2Protocol'
 }
 
 war {
@@ -63,5 +48,13 @@ war {
 }
 
 wrapper {
-	gradleVersion = '7.4.2'
+	gradleVersion = '8.12.1'
+}
+
+gretty {
+    httpPort = 8080
+    contextPath = '/'
+    servletContainer = 'tomcat10'
+    //reloadOnClassChange=true
+    managedClassReload=true
 }

--- a/src/main/java/net/nicoleroy/dirf/springconfig/ThymeleafConfig.java
+++ b/src/main/java/net/nicoleroy/dirf/springconfig/ThymeleafConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.ViewResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.thymeleaf.spring4.SpringTemplateEngine;
 import org.thymeleaf.spring4.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.spring4.view.ThymeleafViewResolver;
@@ -21,7 +21,7 @@ import org.springframework.context.annotation.PropertySources;
  */
 @Configuration
 @PropertySources(value = {@PropertySource("classpath:/thymeleaf.properties")})
-public class ThymeleafConfig extends WebMvcConfigurerAdapter implements ApplicationContextAware {
+public class ThymeleafConfig implements ApplicationContextAware, WebMvcConfigurer {
 
     private ApplicationContext applicationContext;
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-         version="3.1">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         metadata-complete="false"
+         version="6.0">
   <context-param>
     <param-name>contextConfigLocation</param-name>
     <param-value>/WEB-INF/applicationContext.xml</param-value>


### PR DESCRIPTION
- Migrated from Tomcat plugin to Gretty plugin for better development experience
- Updated Gradle wrapper from 7.4.2 to 8.12.1
- Updated Spring WebMVC from 6.0.0-M3 to 6.0.23 (stable release)
- Reverted ldaptive from 2.1.0 to 1.3.3 for compatibility
- Updated gradle-versions-plugin from 0.42.0 to 0.52.0
- Fixed deprecated WebMvcConfigurerAdapter to WebMvcConfigurer interface in ThymeleafConfig
- Migrated web.xml from JavaEE (javax) to Jakarta EE namespace (web-app 3.1 to 6.0)
- Added managedClassReload to Gretty for hot-reloading during development

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)