### PR TITLE
Fix security vulnerabilities in jackson-databind and Thymeleaf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ repositories {
 dependencies {
    providedCompile("javax.servlet:javax.servlet-api:4.0.1")
    implementation("org.springframework:spring-webmvc:6.0.23")
-   implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2")
-   implementation("org.thymeleaf:thymeleaf-spring4:3.0.15.RELEASE")
+   implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
+   implementation("org.thymeleaf:thymeleaf-spring6:3.1.3.RELEASE")
    implementation("org.ldaptive:ldaptive:1.3.3")
     implementation("com.typesafe:config:1.4.2")
    testImplementation("junit:junit:4.13.2")

--- a/src/main/java/net/nicoleroy/dirf/springconfig/ThymeleafConfig.java
+++ b/src/main/java/net/nicoleroy/dirf/springconfig/ThymeleafConfig.java
@@ -6,12 +6,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.thymeleaf.spring4.SpringTemplateEngine;
-import org.thymeleaf.spring4.templateresolver.SpringResourceTemplateResolver;
-import org.thymeleaf.spring4.view.ThymeleafViewResolver;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
+import org.thymeleaf.spring6.view.ThymeleafViewResolver;
 import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.ITemplateResolver;
-//import org.thymeleaf.extras.springsecurity3.dialect.SpringSecurityDialect;
+//import org.thymeleaf.extras.springsecurity6.dialect.SpringSecurityDialect;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
 


### PR DESCRIPTION
Security Updates:
- Updated jackson-databind from 2.13.2.2 to 2.17.2 Fixes resource exhaustion vulnerabilities allowing DoS attacks
- Updated Thymeleaf from 3.0.15 (spring4) to 3.1.3 (spring6) Fixes CVE-2023-38286 (CVSS 7.5) - sandbox bypass via crafted HTML
- Updated ThymeleafConfig imports from spring4 to spring6 packages
- Kept ldaptive at 1.3.3 (upgrading to 2.x requires significant code refactoring)

All 18 unit tests pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)