### PR TITLE
Replace printStackTrace calls with proper SLF4J logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
    implementation("org.thymeleaf:thymeleaf-spring6:3.1.3.RELEASE")
    implementation("org.ldaptive:ldaptive:2.3.2")
     implementation("com.typesafe:config:1.4.2")
+   implementation("org.slf4j:slf4j-api:2.0.9")
+   runtimeOnly("ch.qos.logback:logback-classic:1.4.14")
    testImplementation("junit:junit:4.13.2")
 }
 

--- a/src/main/java/net/nicoleroy/directory/LDAPUtils.java
+++ b/src/main/java/net/nicoleroy/directory/LDAPUtils.java
@@ -4,12 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author nckroy
  *
  */
 public class LDAPUtils {
+
+	private static final Logger logger = LoggerFactory.getLogger(LDAPUtils.class);
 
 	public static List<DirectoryPerson> LDAPInfoListToDirectoryPersonList(List<LDAPInfo> convertList) {
 		List<DirectoryPerson> results = new ArrayList<DirectoryPerson>();
@@ -31,20 +35,15 @@ public class LDAPUtils {
 					Method setter = dp.getClass().getMethod(eNameBuilder.toString(), params);
 					setter.invoke(dp, getConcatAttrValueString(element.values));
 				} catch (NoSuchMethodException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					logger.debug("No setter method found for LDAP attribute: {}", element.name);
 				} catch (SecurityException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					logger.error("Security exception accessing setter for attribute: {}", element.name, e);
 				} catch (IllegalAccessException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					logger.error("Illegal access exception setting attribute: {}", element.name, e);
 				} catch (IllegalArgumentException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					logger.error("Illegal argument exception setting attribute: {}", element.name, e);
 				} catch (InvocationTargetException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
+					logger.error("Invocation target exception setting attribute: {}", element.name, e);
 				}
 			}
 			results.add(dp);

--- a/src/main/java/net/nicoleroy/dirf/controller/LdapSearchController.java
+++ b/src/main/java/net/nicoleroy/dirf/controller/LdapSearchController.java
@@ -6,6 +6,8 @@ import net.nicoleroy.directory.LDAPFactory;
 import net.nicoleroy.directory.LDAPInfo;
 import net.nicoleroy.directory.LDAPUtils;
 import org.ldaptive.LdapException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -23,6 +25,8 @@ import org.springframework.context.annotation.PropertySources;
 @Controller
 @PropertySources(value = {@PropertySource("classpath:/controller.properties")})
 public class LdapSearchController {
+
+	private static final Logger logger = LoggerFactory.getLogger(LdapSearchController.class);
 
 	private LDAPFactory factory = new LDAPFactory();
 
@@ -50,11 +54,9 @@ public class LdapSearchController {
 				ldapInfo=factory.findSingleEntry(sb.toString());
 
 			} catch (LdapException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				logger.error("LDAP error while searching for user with userid: {}", userid, e);
 			} catch (Exception e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				logger.error("Unexpected error while searching for user with userid: {}", userid, e);
 			}
 		}
 		model.addAttribute("ldapInfo", ldapInfo.getAttributeInfoElementList());
@@ -68,8 +70,7 @@ public class LdapSearchController {
 			try {
 				searchResult.setSearchResults(LDAPUtils.LDAPInfoListToDirectoryPersonList(factory.findEntriesByStringSearch(searchString)));
 			} catch (LdapException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				logger.error("LDAP error while searching for: {}", searchString, e);
 			}
 
 			if(searchResult.getSearchResults().size() == 1)


### PR DESCRIPTION
Changes:
- Added SLF4J API 2.0.9 and Logback Classic 1.4.14 dependencies
- Replaced all printStackTrace() calls with proper logging in LdapSearchController
  - LDAP errors logged at ERROR level with context (userid/search string)
  - Unexpected errors logged at ERROR level
- Replaced all printStackTrace() calls with proper logging in LDAPUtils
  - NoSuchMethodException logged at DEBUG level (expected for unmapped attributes)
  - Other reflection exceptions logged at ERROR level with attribute context
- Added static Logger instances to both classes

Benefits:
- Proper error tracking and debugging capabilities
- Contextual information included in log messages
- Configurable log levels via logback.xml
- Production-ready error handling

All 18 unit tests pass successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [Happy](https://happy.engineering)